### PR TITLE
Register LanguageResolvers by interface

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,12 +4,6 @@ services:
         autoconfigure: true
 
 
-    _instanceof:
-        numero2\DeepLBundle\LanguageResolver\LanguageResolverInterface:
-            tags: ['numero2.deepl_language_resolver']
-            lazy: true
-
-
     numero2_deepl.api:
         class: numero2\DeepLBundle\Api\DeepLApi
         public: true

--- a/src/DependencyInjection/DeepLExtension.php
+++ b/src/DependencyInjection/DeepLExtension.php
@@ -12,6 +12,7 @@
 
 namespace numero2\DeepLBundle\DependencyInjection;
 
+use numero2\DeepLBundle\LanguageResolver\LanguageResolverInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -52,6 +53,12 @@ class DeepLExtension extends Extension implements PrependExtensionInterface {
         }
 
         $container->setParameter('contao.deepl.api_key', $apiKey);
+
+        $container
+            ->registerForAutoconfiguration(LanguageResolverInterface::class)
+            ->addTag('numero2.deepl_language_resolver')
+            ->setLazy(true)
+        ;
     }
 
 


### PR DESCRIPTION
I had to implement my own language resolver in my application due to custom extensions. With this change, any service in any bundle that implements the `LanguageResolverInterface` is automatically tagged (if autoconfiguration is enabled).