### PR TITLE
Automatically resolve the environment variable

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface {
             ->children()
                 ->scalarNode('api_key')
                     ->info('The DeepL API key.')
-                    ->defaultValue('')
+                    ->defaultValue('%env(DEEPL_API_KEY)%')
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/DeepLExtension.php
+++ b/src/DependencyInjection/DeepLExtension.php
@@ -36,22 +36,10 @@ class DeepLExtension extends Extension implements PrependExtensionInterface {
      */
     public function prepend( ContainerBuilder $container ): void {
 
-        $configuration = new Configuration((string) $container->getParameter('kernel.project_dir'));
+        $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $container->getExtensionConfig($this->getAlias()));
 
-        $apiKey = $config['api_key'];
-
-        // try reading api key from ENV
-        if( empty($apiKey) ) {
-
-            $envApiKey = getenv('DEEPL_API_KEY') ?: ($_ENV['DEEPL_API_KEY'] ?? null);
-
-            if( !empty($envApiKey) ) {
-                $apiKey = $envApiKey;
-            }
-        }
-
-        $container->setParameter('contao.deepl.api_key', $apiKey);
+        $container->setParameter('contao.deepl.api_key', $config['api_key']);
     }
 
 


### PR DESCRIPTION
With the current code, you must rebuild the cache to detect a new (or changed) environment variable. This PR changes this to use Symfony to read the environment variable dynamically.

I also think the bundle should not prepend the configuration, since that is only meant to be used if you want to configure an third-party bundle, but not your own bundle. But I didn't want to change too much in this PR since thats kinda unrelated 🙃 