### PR TITLE
Change key to keyCode since option + t is a mac shortcut

### DIFF
--- a/public/js/backend.js
+++ b/public/js/backend.js
@@ -148,7 +148,7 @@
 
             document.addEventListener('keydown',(e)=> {
 
-                if( e.altKey && e.key === 't') {
+                if( e.altKey && e.keyCode === 84) {
 
                     e.preventDefault();
                     console.info('DeepL: Translating all Widgets');


### PR DESCRIPTION
On mac sequoia the shortcut option + t creates special char "†", so `e.key === 't'` will be always false.

I didn't find a way to change that shortcut behavior, so i thought it could be better to change e.key === 't' to e.keyCode === 84 to prevent some kind of system predefined shortcut garbage.